### PR TITLE
Update naming in HelloAsync example

### DIFF
--- a/01-hello-async.rb
+++ b/01-hello-async.rb
@@ -11,13 +11,13 @@ require 'concurrent'
 class HelloAsync
   include Concurrent::Async
 
-  def hello
+  def hello_method
     sleep(3)
     puts "Hello! My object id is '#{object_id}' and I'm running in thread '#{Thread.current.object_id}'."
   end
 end
 
-hello = HelloAsync.new
+hello_instance = HelloAsync.new
 
 print '> '
 while (input = gets)
@@ -26,10 +26,10 @@ while (input = gets)
     puts 'Quitting...'
     exit(0)
   when /^l(ist)?/ then puts "Currently have #{Thread.list.count} threads."
-  when /^async/ then hello.async.hello
-  when /^await/ then hello.await.hello
-  when /^new-async/ then HelloAsync.new.async.hello
-  when /^new-await/ then HelloAsync.new.await.hello
+  when /^async/ then hello_instance.async.hello_method
+  when /^await/ then hello_instance.await.hello_method
+  when /^new-async/ then HelloAsync.new.async.hello_method
+  when /^new-await/ then HelloAsync.new.await.hello_method
   else puts "Received unknown input: #{input}"
   end
 


### PR DESCRIPTION
When working on a post to write about this example, having `hello` for
the name of the variable holding the instance and the name of the method
made things a bit confusing.

This commit creatively renames the method to `hello_method` and the
`HelloAsync` instance to `hello_instance`.
